### PR TITLE
Avoid IndexError when parsing malformed GPS data

### DIFF
--- a/exif2pandas/clean.py
+++ b/exif2pandas/clean.py
@@ -36,7 +36,7 @@ def clean_exif_data(path, data, ignore_keys=IGNORE_STARTSWITH) -> dict:
     """
     Cleans exif data for each picture
     """
-    lat, lon = get_exif_location(data)
+    lat, lon = get_exif_location(path, data)
     size = os.path.getsize(path) / 1024 ** 2
 
     cleaned_data = {

--- a/exif2pandas/gps_utils.py
+++ b/exif2pandas/gps_utils.py
@@ -16,7 +16,7 @@ def convert_to_degress(value):
     return d + (m / 60.0) + (s / 3600.0)
 
 
-def get_exif_location(exif_data):
+def get_exif_location(path, exif_data):
     """
     Returns the latitude and longitude, if available, from the provided exif_data
     (obtained through get_exif_data above)
@@ -29,14 +29,21 @@ def get_exif_location(exif_data):
     gps_longitude = exif_data.get('GPS GPSLongitude')
     gps_longitude_ref = exif_data.get('GPS GPSLongitudeRef')
 
-    if gps_latitude and gps_latitude_ref and gps_longitude and gps_longitude_ref:
-        lat = convert_to_degress(gps_latitude)
-        if gps_latitude_ref.values[0] != 'N':
-            lat = round(0 - lat, 6)
+    try:
+        if len(gps_latitude.values) > 0 and \
+           len(gps_latitude_ref.values) > 0 and \
+           len(gps_longitude.values) > 0 and \
+           len(gps_longitude_ref.values) > 0:
 
-        lon = convert_to_degress(gps_longitude)
-        if gps_longitude_ref.values[0] != 'E':
-            lon = round(0 - lon, 6)
-        return lat, lon
+            lat = convert_to_degress(gps_latitude)
+            if gps_latitude_ref.values[0] != 'N':
+                lat = round(0 - lat, 6)
 
-    return None, None
+            lon = convert_to_degress(gps_longitude)
+            if gps_longitude_ref.values[0] != 'E':
+                lon = round(0 - lon, 6)
+
+    except IndexError:
+        print(f"Location data not valid: {path}")
+
+    return lat, lon


### PR DESCRIPTION
Hey @Visgean,

When running exif2pandas on my Photo library,  I encountered an error that caused exif2pandas to crash.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.10/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/fede/.local/lib/python3.10/site-packages/exif2pandas-1.4-py3.10.egg/exif2pandas/utils.py", line 29, in get_exif
    return clean_exif_data(path, exifread.process_file(f))
  File "/home/fede/.local/lib/python3.10/site-packages/exif2pandas-1.4-py3.10.egg/exif2pandas/clean.py", line 39, in clean_exif_data
    lat, lon = get_exif_location(data)
  File "/home/fede/.local/lib/python3.10/site-packages/exif2pandas-1.4-py3.10.egg/exif2pandas/gps_utils.py", line 34, in get_exif_location
    if gps_latitude_ref.values[0] != 'N':
IndexError: string index out of range
```

I fixed the error in this Pull Request by checking that the size of gps attributes is > 0 before accessing them, and adding a try/except to avoid crashes in case of further errors.

After this fix my Photo library can be fully processed, and it takes just 7m20s for 22K pictures and 261GB, very fast!

Thank you for the nice project, let me know if you have doubts on this PR.

By the way, this is one of the photos causing the error, in case you want to check yourself.
![IMG_20190814_191606-01](https://user-images.githubusercontent.com/7339271/219967745-1500c62d-75a5-4bfb-859e-4e1836f8b343.jpeg)
